### PR TITLE
Replace binary assets with vector web styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,68 @@ Clone the repository and open it in Android Studio:
 
 ```bash
 git clone https://github.com/JohnAndreiCabili/Mangosoft.git
+```
+
+---
+
+## Running the installable web experience
+
+The `web/` directory contains a Progressive Web App (PWA) port of Mangosoft that you can run and install on macOS, Windows, or Linux. You only need a static file server (Python's built-in server works great) and a modern Chromium, Edge, or Safari (macOS 17+) browser.
+
+### 1. Install prerequisites (if needed)
+
+- **Python 3.8+**
+  - macOS ships with Python 3. To upgrade, run `brew install python`.
+  - On Windows, install Python from <https://www.python.org/downloads/> and be sure to check **Add python.exe to PATH**.
+  - Most Linux distributions already include Python 3; otherwise install it with your package manager (e.g., `sudo apt install python3`).
+- **Modern browser** with PWA support (Chrome 113+, Edge 113+, or Safari 17+ on macOS).
+
+### 2. Start the local server
+
+From the repository root run the command that matches your platform:
+
+<details>
+<summary><strong>macOS / Linux (Terminal)</strong></summary>
+
+```bash
+cd /path/to/Mangosoft/web
+python3 -m http.server 4173
+```
+
+</details>
+
+<details>
+<summary><strong>Windows (PowerShell)</strong></summary>
+
+```powershell
+cd C:\path\to\Mangosoft\web
+py -m http.server 4173
+```
+
+</details>
+
+If port `4173` is busy, pick another port (e.g., `8080`) and use the same port number when opening the browser.
+
+### 3. Open the app in your browser
+
+Navigate to <http://localhost:4173>. The splash screen will appear, followed by the onboarding carousel. You can now upload images, capture new photos (allow camera access when prompted), and view the AI-generated classification results.
+
+### 4. Install the PWA (optional but recommended)
+
+1. With the app open at `http://localhost:4173`, look for the **Install Mangosoft** prompt:
+   - **Chrome / Edge:** Click the install icon (+) in the address bar.
+   - **Safari (macOS 17+):** Use the **Share → Add to Dock** menu item.
+2. Confirm the prompt. The app now appears in your application launcher and opens in its own window. Cached assets mean the UI loads instantly even when offline (API calls still need an internet connection).
+
+Whenever you change files inside `web/`, refresh the page once so the service worker can download the latest assets. Reinstalling is not required.
+
+### 5. Stop the server
+
+Return to the Terminal/PowerShell window and press `Ctrl + C` to shut down the local server when you are done.
+
+### Troubleshooting
+
+- **Blank page after updating files:** Refresh twice to bust the service worker cache, or run `navigator.serviceWorker.getRegistrations().then(regs => regs.forEach(reg => reg.unregister()))` from DevTools and reload.
+- **Camera button disabled:** Make sure your browser has camera permissions and that you're running over `http://localhost` or `https://` (required for getUserMedia).
+- **Port already in use:** Pass a different port to the `http.server` command and update the browser URL accordingly.
+- **Windows firewall prompt:** Allow Python to communicate on private networks so the local browser can connect.

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,62 @@
+# Mangosoft Web
+
+A browser-based port of the Mangosoft Android application. The web experience mirrors the native flow: splash and onboarding screens lead to scanning options where users can upload or capture mango photos, receive AI-powered classification, view confidence and quality class, and get a price estimate.
+
+## Getting Started
+
+You only need a static file server to run the web build.
+
+### Quick start on macOS
+
+1. Open the **Terminal** application (`⌘ + Space`, type "Terminal").
+2. Navigate into the project folder and start the built-in Python web server:
+
+   ```bash
+   cd /path/to/Mangosoft/web
+   python3 -m http.server 4173
+   ```
+
+   macOS ships with Python 3, but if you have [Homebrew](https://brew.sh/) installed you can also run `brew install python` to
+   get the latest version.
+3. Open your browser to <http://localhost:4173>.
+4. The first time you try to capture an image, macOS will prompt you to allow camera access. Accept the prompt to use the
+   in-browser camera capture.
+
+When you're done, return to Terminal and press `Ctrl + C` to stop the server.
+
+### Other platforms
+
+From any operating system you can start a static server by running:
+
+```bash
+# From the repository root
+cd web
+python -m http.server 4173
+```
+
+Then open your browser to <http://localhost:4173>.
+
+> **Tip:** Any static hosting service (GitHub Pages, Netlify, Firebase Hosting, etc.) can serve the contents of this folder without additional build steps.
+
+### Install as a desktop app (Progressive Web App)
+
+Mangosoft Web is a Progressive Web App, so once it is running in your browser you can install it like a native application:
+
+1. Start the local server (see instructions above) and open <http://localhost:4173> in **Chrome**, **Edge**, or **Safari (macOS 17+)**.
+2. Look for the **Install** or **Add to Dock** icon in the address bar and follow the prompt to install Mangosoft.
+3. After installation the app appears in your OS launcher and opens in its own window. Cached assets mean the UI loads instantly even when offline (API calls still require connectivity).
+
+If you update the code, refresh the page once to allow the service worker to download the latest files before reinstalling.
+
+## Environment Variables
+
+The application targets the same hosted APIs as the Android app:
+
+- CNN classification: `https://mangosoft-722758638200.asia-southeast1.run.app/predict`
+- Random Forest price estimation: `https://mangosoft-e87cfb72dc61.herokuapp.com/predict`
+
+If you need to point to alternative deployments, update the `BASE_URL_YOLO` and `BASE_URL_RFR` constants inside `web/main.js`.
+
+## Saving Results
+
+The **Save a Copy** button uses [`html2canvas`](https://html2canvas.hertzen.com/) from a CDN to export the result card. The feature requires network access the first time it runs so the script can be downloaded. Once cached by the browser, it continues to work offline.

--- a/web/assets/mangosoft-icon.svg
+++ b/web/assets/mangosoft-icon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#f57c00" />
+      <stop offset="60%" stop-color="#fbc02d" />
+      <stop offset="100%" stop-color="#ffe082" />
+    </linearGradient>
+  </defs>
+  <rect width="192" height="192" rx="48" fill="url(#g)" />
+  <path
+    d="M64 136c-8.8 0-16-7.2-16-16V72c0-8.8 7.2-16 16-16h6c6.9 0 12.5 4.5 14.6 10.6l12.9 38.8c.7 2.1 3.7 2.1 4.4 0l12.9-38.8C129 60.5 134.5 56 141.5 56h6c8.8 0 16 7.2 16 16v48c0 8.8-7.2 16-16 16h-8.9c-6.7 0-12.6-4.3-14.7-10.7l-5.4-16.1c-.7-2.1-3.7-2.1-4.4 0l-5.4 16.1c-2.1 6.4-8 10.7-14.7 10.7z"
+    fill="#fff"
+  />
+</svg>

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Mangosoft Web</title>
+    <link rel="icon" type="image/svg+xml" href="assets/mangosoft-icon.svg" />
+    <meta name="theme-color" content="#fbc02d" />
+    <link rel="manifest" href="manifest.webmanifest" />
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <script defer src="main.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+  </head>
+  <body>
+    <div id="app" class="app">
+      <section id="splash" class="screen splash-screen" aria-hidden="false">
+        <div class="logo-badge" aria-hidden="true">
+          <span>MS</span>
+        </div>
+        <p class="splash-text">Classify. Assess. Price.</p>
+      </section>
+
+      <section id="onboarding" class="screen onboarding" aria-hidden="true">
+        <div class="onboarding-visual" aria-hidden="true">
+          <div class="visual-blob blob-one"></div>
+          <div class="visual-blob blob-two"></div>
+          <span class="visual-glyph">🥭</span>
+        </div>
+        <div class="onboarding-card">
+          <div id="onboarding-slide" class="onboarding-slide" aria-live="polite"></div>
+          <div class="progress-wrapper" aria-hidden="true">
+            <div class="progress-bar">
+              <div id="progress-indicator" class="progress-indicator"></div>
+            </div>
+          </div>
+          <div class="onboarding-actions">
+            <button id="skip-btn" class="btn ghost">Skip</button>
+            <button id="back-btn" class="btn ghost">Back</button>
+            <button id="next-btn" class="btn primary">Next</button>
+            <button id="start-btn" class="btn primary">Get Started</button>
+          </div>
+        </div>
+      </section>
+
+      <section id="home" class="screen home" aria-hidden="true">
+        <header class="home-header">
+          <div class="brand-title" aria-label="Mangosoft">Mangosoft</div>
+          <h1>How would you like to scan your mangoes?</h1>
+        </header>
+        <div class="scan-options">
+          <button id="upload-btn" class="scan-option" type="button">
+            <span class="scan-icon upload" aria-hidden="true"></span>
+            <div>
+              <h2>Upload an Image</h2>
+              <p>Upload a mango photo from your gallery to start scanning.</p>
+            </div>
+          </button>
+          <button id="camera-btn" class="scan-option" type="button">
+            <span class="scan-icon camera" aria-hidden="true"></span>
+            <div>
+              <h2>Capture an Image</h2>
+              <p>Use your device camera to capture a mango photo instantly.</p>
+            </div>
+          </button>
+        </div>
+        <input id="gallery-input" class="sr-only" type="file" accept="image/*" />
+        <input
+          id="camera-input"
+          class="sr-only"
+          type="file"
+          accept="image/*"
+          capture="environment"
+        />
+      </section>
+
+      <section id="result" class="screen result" aria-hidden="true">
+        <header class="result-header">
+          <div class="brand-title" aria-label="Mangosoft">Mangosoft</div>
+        </header>
+        <article class="result-card" id="result-card">
+          <figure class="result-image">
+            <img id="preview-image" alt="Scanned mango preview" />
+          </figure>
+          <dl class="result-details">
+            <div>
+              <dt>Classification</dt>
+              <dd id="classification-value">—</dd>
+            </div>
+            <div>
+              <dt>Confidence</dt>
+              <dd>
+                <div class="confidence">
+                  <div class="progress-bar" aria-hidden="true">
+                    <div id="confidence-indicator" class="progress-indicator"></div>
+                  </div>
+                  <span id="confidence-value">—</span>
+                </div>
+              </dd>
+            </div>
+            <div>
+              <dt>Quality Class</dt>
+              <dd id="class-value">—</dd>
+            </div>
+            <div>
+              <dt>Estimated Price</dt>
+              <dd id="price-value">—</dd>
+            </div>
+            <div>
+              <dt>Generated</dt>
+              <dd id="timestamp-value">—</dd>
+            </div>
+          </dl>
+          <p id="result-error" class="result-error" role="alert" hidden>
+            Mango not detected. Please try again with a clearer photo.
+          </p>
+        </article>
+        <div class="result-actions">
+          <button id="save-btn" class="btn outlined" type="button">Save a Copy</button>
+          <button id="rescan-btn" class="btn primary" type="button">Scan Again</button>
+        </div>
+      </section>
+    </div>
+
+    <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
+    <div id="loading" class="loading" hidden>
+      <div class="spinner" role="status" aria-live="assertive" aria-busy="true"></div>
+      <p>Analyzing your mango…</p>
+    </div>
+  </body>
+</html>

--- a/web/main.js
+++ b/web/main.js
@@ -1,0 +1,420 @@
+const screens = {
+  splash: document.getElementById("splash"),
+  onboarding: document.getElementById("onboarding"),
+  home: document.getElementById("home"),
+  result: document.getElementById("result"),
+};
+
+const onboardingSlide = document.getElementById("onboarding-slide");
+const progressIndicator = document.getElementById("progress-indicator");
+const skipBtn = document.getElementById("skip-btn");
+const backBtn = document.getElementById("back-btn");
+const nextBtn = document.getElementById("next-btn");
+const startBtn = document.getElementById("start-btn");
+const uploadBtn = document.getElementById("upload-btn");
+const cameraBtn = document.getElementById("camera-btn");
+const galleryInput = document.getElementById("gallery-input");
+const cameraInput = document.getElementById("camera-input");
+const loadingOverlay = document.getElementById("loading");
+const toast = document.getElementById("toast");
+
+const previewImage = document.getElementById("preview-image");
+const classificationValue = document.getElementById("classification-value");
+const confidenceValue = document.getElementById("confidence-value");
+const confidenceIndicator = document.getElementById("confidence-indicator");
+const classValue = document.getElementById("class-value");
+const priceValue = document.getElementById("price-value");
+const timestampValue = document.getElementById("timestamp-value");
+const errorMessage = document.getElementById("result-error");
+const saveBtn = document.getElementById("save-btn");
+const rescanBtn = document.getElementById("rescan-btn");
+const resultCard = document.getElementById("result-card");
+
+const BASE_URL_YOLO = "https://mangosoft-722758638200.asia-southeast1.run.app/";
+const BASE_URL_RFR = "https://mangosoft-e87cfb72dc61.herokuapp.com/";
+
+let onboardingIndex = 0;
+let selectedFile = null;
+let previewUrl = null;
+
+const slides = [
+  {
+    title: "Welcome to Mangosoft",
+    description: "Identify your mangoes in seconds with AI-powered precision.",
+    emoji: "🥭",
+    accent: "",
+  },
+  {
+    title: "Detect Mango Varieties",
+    description: "Instantly recognize Carabao, Pico, and Indian (Katchamitha) mangoes.",
+    emoji: "🧠",
+    accent: "accent-growth",
+  },
+  {
+    title: "Scan, Assess, and Price",
+    description: "Snap or upload a photo to learn the type, quality class, and estimated price.",
+    emoji: "💰",
+    accent: "accent-price",
+  },
+];
+
+const showScreen = (target) => {
+  Object.values(screens).forEach((screen) => {
+    screen.classList.remove("active");
+    screen.setAttribute("aria-hidden", "true");
+  });
+
+  const activeScreen = screens[target];
+  activeScreen.classList.add("active");
+  activeScreen.setAttribute("aria-hidden", "false");
+};
+
+const renderOnboardingSlide = () => {
+  const slide = slides[onboardingIndex];
+  const accentClass = slide.accent ? ` ${slide.accent}` : "";
+  onboardingSlide.innerHTML = `
+    <div class="slide-visual${accentClass}" aria-hidden="true">
+      <span>${slide.emoji}</span>
+    </div>
+    <div>
+      <h2>${slide.title}</h2>
+      <p>${slide.description}</p>
+    </div>
+  `;
+
+  const progress = ((onboardingIndex + 1) / slides.length) * 100;
+  progressIndicator.style.width = `${progress}%`;
+
+  backBtn.style.display = onboardingIndex === 0 ? "none" : "inline-flex";
+  skipBtn.style.display = onboardingIndex === 0 ? "inline-flex" : "none";
+  nextBtn.style.display = onboardingIndex === slides.length - 1 ? "none" : "inline-flex";
+  startBtn.style.display = onboardingIndex === slides.length - 1 ? "inline-flex" : "none";
+};
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const showToast = (message, duration = 3000) => {
+  toast.textContent = message;
+  toast.hidden = false;
+  setTimeout(() => {
+    toast.hidden = true;
+  }, duration);
+};
+
+const toggleLoading = (show) => {
+  loadingOverlay.hidden = !show;
+};
+
+const resetResult = () => {
+  previewImage.src = "";
+  classificationValue.textContent = "—";
+  confidenceValue.textContent = "—";
+  confidenceIndicator.style.width = "0";
+  classValue.textContent = "—";
+  priceValue.textContent = "—";
+  timestampValue.textContent = "—";
+  errorMessage.hidden = true;
+};
+
+const determineTypeAndClass = (mangoType) => {
+  if (!mangoType) {
+    return {
+      type: "Unknown Type",
+      mangoClass: "Unknown Class",
+      flags: {
+        Type_Carabao: 0,
+        Type_Indian: 0,
+        Type_Pico: 0,
+        Class_ClassA: 0,
+        Class_ClassB: 0,
+        Class_ClassC: 0,
+        Class_ClassD: 0,
+        Class_ClassE: 0,
+      },
+    };
+  }
+
+  const normalized = mangoType.toUpperCase();
+
+  const typeFlags = {
+    Type_Carabao: Number(/K/.test(normalized)),
+    Type_Indian: Number(/I/.test(normalized)),
+    Type_Pico: Number(/P/.test(normalized)),
+  };
+
+  const classFlags = {
+    Class_ClassA: Number(/CLASS[\s-]*A/.test(normalized)),
+    Class_ClassB: Number(/CLASS[\s-]*B/.test(normalized)),
+    Class_ClassC: Number(/CLASS[\s-]*C/.test(normalized)),
+    Class_ClassD: Number(/CLASS[\s-]*D/.test(normalized)),
+    Class_ClassE: Number(/CLASS[\s-]*E/.test(normalized)),
+  };
+
+  const typeLabel = typeFlags.Type_Carabao
+    ? "Carabao"
+    : typeFlags.Type_Indian
+    ? "Indian"
+    : typeFlags.Type_Pico
+    ? "Pico"
+    : "Unknown Type";
+
+  const classLabel = classFlags.Class_ClassA
+    ? "CLASS A"
+    : classFlags.Class_ClassB
+    ? "CLASS B"
+    : classFlags.Class_ClassC
+    ? "CLASS C"
+    : classFlags.Class_ClassD
+    ? "CLASS D"
+    : classFlags.Class_ClassE
+    ? "CLASS E"
+    : "Unknown Class";
+
+  return {
+    type: typeLabel,
+    mangoClass: classLabel,
+    flags: {
+      ...typeFlags,
+      ...classFlags,
+    },
+  };
+};
+
+const buildRfrPayload = (flags) => {
+  const now = new Date();
+  const year = now.getFullYear();
+  const monthIndex = now.getMonth();
+
+  const monthFields = Array.from({ length: 12 }, (_, index) => (index === monthIndex ? 1 : 0));
+
+  const payload = {
+    Year: year,
+    "Type_Carabao": flags.Type_Carabao,
+    "Type_Indian": flags.Type_Indian,
+    "Type_Pico": flags.Type_Pico,
+    "Class_Class A": flags.Class_ClassA,
+    "Class_Class B": flags.Class_ClassB,
+    "Class_Class C": flags.Class_ClassC,
+    "Class_Class D": flags.Class_ClassD,
+    "Class_Class E": flags.Class_ClassE,
+    Month_January: monthFields[0],
+    Month_February: monthFields[1],
+    Month_March: monthFields[2],
+    Month_April: monthFields[3],
+    Month_May: monthFields[4],
+    Month_June: monthFields[5],
+    Month_July: monthFields[6],
+    Month_August: monthFields[7],
+    Month_September: monthFields[8],
+    Month_October: monthFields[9],
+    Month_November: monthFields[10],
+    Month_December: monthFields[11],
+  };
+
+  return payload;
+};
+
+const callCnnApi = async (file) => {
+  const formData = new FormData();
+  formData.append("file", file);
+
+  const response = await fetch(new URL("predict", BASE_URL_YOLO).toString(), {
+    method: "POST",
+    body: formData,
+  });
+
+  if (!response.ok) {
+    throw new Error(`CNN API error: ${response.status}`);
+  }
+
+  return response.json();
+};
+
+const callRfrApi = async (payload) => {
+  const response = await fetch(new URL("predict", BASE_URL_RFR).toString(), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error(`RFR API error: ${response.status}`);
+  }
+
+  return response.json();
+};
+
+const formatPrice = (value) => {
+  if (!value || value === "Error") {
+    return "Unknown";
+  }
+
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) {
+    return `₱${numeric.toFixed(2)}/kg`;
+  }
+
+  if (Array.isArray(value)) {
+    return value.join(", ");
+  }
+
+  return value;
+};
+
+const updateResultView = ({
+  mangoType,
+  confidence,
+  mangoClass,
+  price,
+}) => {
+  classificationValue.textContent = mangoType ? mangoType : "Unknown";
+
+  if (typeof confidence === "number" && Number.isFinite(confidence)) {
+    const percent = Math.min(100, Math.max(0, confidence * 100));
+    confidenceIndicator.style.width = `${percent}%`;
+    confidenceValue.textContent = `${percent.toFixed(2)}%`;
+  } else {
+    confidenceIndicator.style.width = "0";
+    confidenceValue.textContent = "—";
+  }
+
+  classValue.textContent = mangoClass;
+  priceValue.textContent = formatPrice(price);
+  timestampValue.textContent = new Date().toLocaleString();
+};
+
+const handleFileSelection = async (file) => {
+  if (!file) {
+    return;
+  }
+
+  resetResult();
+
+  if (previewUrl) {
+    URL.revokeObjectURL(previewUrl);
+  }
+
+  previewUrl = URL.createObjectURL(file);
+  previewImage.src = previewUrl;
+
+  toggleLoading(true);
+  try {
+    const cnnResponse = await callCnnApi(file);
+    const { type, mangoClass, flags } = determineTypeAndClass(cnnResponse?.mango_type);
+
+    let priceResponse = null;
+    try {
+      const rfrPayload = buildRfrPayload(flags);
+      priceResponse = await callRfrApi(rfrPayload);
+    } catch (error) {
+      console.error(error);
+    }
+
+    updateResultView({
+      mangoType: type,
+      confidence: cnnResponse?.confidence,
+      mangoClass,
+      price: priceResponse,
+    });
+
+    errorMessage.hidden = true;
+    showScreen("result");
+  } catch (error) {
+    console.error(error);
+    errorMessage.hidden = false;
+    updateResultView({ mangoType: "Unknown", confidence: null, mangoClass: "Unknown", price: "Unknown" });
+    showToast("We couldn't analyze the image. Please try again.");
+    showScreen("result");
+  } finally {
+    toggleLoading(false);
+  }
+};
+
+const saveResultCard = async () => {
+  if (typeof html2canvas !== "function") {
+    showToast("Download is unavailable offline.");
+    return;
+  }
+
+  try {
+    const canvas = await html2canvas(resultCard);
+    canvas.toBlob((blob) => {
+      if (!blob) {
+        showToast("Unable to save the result right now.");
+        return;
+      }
+      const link = document.createElement("a");
+      const dateSuffix = new Date().toISOString().replace(/[:.]/g, "-");
+      link.href = URL.createObjectURL(blob);
+      link.download = `mangosoft-result-${dateSuffix}.png`;
+      link.click();
+      URL.revokeObjectURL(link.href);
+      showToast("Result saved to your device!");
+    });
+  } catch (error) {
+    console.error(error);
+    showToast("Failed to save the result. Please try again.");
+  }
+};
+
+skipBtn.addEventListener("click", () => {
+  showScreen("home");
+});
+
+backBtn.addEventListener("click", () => {
+  onboardingIndex = Math.max(0, onboardingIndex - 1);
+  renderOnboardingSlide();
+});
+
+nextBtn.addEventListener("click", () => {
+  onboardingIndex = Math.min(slides.length - 1, onboardingIndex + 1);
+  renderOnboardingSlide();
+});
+
+startBtn.addEventListener("click", () => {
+  showScreen("home");
+});
+
+uploadBtn.addEventListener("click", () => galleryInput.click());
+
+cameraBtn.addEventListener("click", () => cameraInput.click());
+
+galleryInput.addEventListener("change", (event) => {
+  const [file] = event.target.files || [];
+  if (file) {
+    selectedFile = file;
+    handleFileSelection(selectedFile);
+  }
+});
+
+cameraInput.addEventListener("change", (event) => {
+  const [file] = event.target.files || [];
+  if (file) {
+    selectedFile = file;
+    handleFileSelection(selectedFile);
+  }
+});
+
+rescanBtn.addEventListener("click", () => {
+  resetResult();
+  showScreen("home");
+});
+
+saveBtn.addEventListener("click", saveResultCard);
+
+document.addEventListener("DOMContentLoaded", async () => {
+  showScreen("splash");
+  await delay(1800);
+  showScreen("onboarding");
+  renderOnboardingSlide();
+});
+
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker
+      .register("./service-worker.js")
+      .catch((error) => console.error("Service worker registration failed", error));
+  });
+}

--- a/web/manifest.webmanifest
+++ b/web/manifest.webmanifest
@@ -1,0 +1,16 @@
+{
+  "name": "Mangosoft",
+  "short_name": "Mangosoft",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#fbc02d",
+  "description": "Classify mangoes, assess quality, and estimate prices with Mangosoft's AI.",
+  "icons": [
+    {
+      "src": "assets/mangosoft-icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/web/service-worker.js
+++ b/web/service-worker.js
@@ -1,0 +1,61 @@
+const CACHE_NAME = "mangosoft-web-v2";
+const APP_SHELL = [
+  "./",
+  "./index.html",
+  "./styles.css",
+  "./main.js",
+  "./manifest.webmanifest",
+  "./assets/mangosoft-icon.svg",
+  "https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"
+];
+
+self.addEventListener("install", (event) => {
+  self.skipWaiting();
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(APP_SHELL))
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((cacheNames) =>
+        Promise.all(
+          cacheNames
+            .filter((name) => name !== CACHE_NAME)
+            .map((name) => caches.delete(name))
+        )
+      )
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+
+  if (request.method !== "GET") {
+    return;
+  }
+
+  const requestUrl = new URL(request.url);
+
+  if (requestUrl.origin === self.location.origin) {
+    event.respondWith(
+      caches.match(request).then((cached) => cached || fetch(request))
+    );
+    return;
+  }
+
+  if (request.destination === "script" && request.url.includes("html2canvas")) {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          const cloned = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(request, cloned));
+          return response;
+        })
+        .catch(() => caches.match(request))
+    );
+  }
+});

--- a/web/styles.css
+++ b/web/styles.css
@@ -1,0 +1,487 @@
+:root {
+  --beige: #fff1d0;
+  --muted-yellow: #f8d278;
+  --orange: #f79f1f;
+  --dark: #1f1f1f;
+  --light: #ffffff;
+  --shadow: rgba(0, 0, 0, 0.15);
+  --radius-lg: 32px;
+  --radius-md: 20px;
+  --radius-sm: 12px;
+  --transition: 200ms ease;
+  font-family: "Poppins", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--muted-yellow);
+  color: var(--dark);
+  min-height: 100vh;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.app {
+  min-height: 100vh;
+  position: relative;
+}
+
+.screen {
+  display: none;
+  min-height: 100vh;
+}
+
+.screen.active {
+  display: flex;
+}
+
+.splash-screen {
+  align-items: center;
+  background: radial-gradient(circle at 20% 20%, rgba(247, 159, 31, 0.4), transparent 60%),
+    radial-gradient(circle at 80% 30%, rgba(255, 255, 255, 0.4), transparent 60%), var(--muted-yellow);
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  gap: 1.5rem;
+}
+
+.logo-badge {
+  align-items: center;
+  background: linear-gradient(135deg, #f57c00, #fbc02d);
+  border-radius: 28px;
+  box-shadow: 0 18px 40px rgba(245, 124, 0, 0.35);
+  color: #fff;
+  display: inline-flex;
+  font-size: clamp(2rem, 6vw, 3.5rem);
+  font-weight: 700;
+  height: clamp(120px, 22vw, 160px);
+  justify-content: center;
+  letter-spacing: 0.1em;
+  padding: 0 1.5rem;
+  text-transform: uppercase;
+}
+
+.splash-text {
+  font-size: clamp(1.4rem, 2.5vw, 2.4rem);
+  font-weight: 600;
+}
+
+.onboarding {
+  background: var(--beige);
+  flex-direction: column;
+}
+
+.onboarding-visual {
+  background: radial-gradient(circle at 20% 30%, rgba(255, 255, 255, 0.6), transparent 60%),
+    radial-gradient(circle at 80% 40%, rgba(255, 183, 77, 0.45), transparent 65%), var(--muted-yellow);
+  flex: 1 1 40%;
+  overflow: hidden;
+  position: relative;
+}
+
+.visual-blob {
+  border-radius: 50%;
+  filter: blur(0px);
+  opacity: 0.6;
+  position: absolute;
+}
+
+.blob-one {
+  background: #ffcc80;
+  height: 220px;
+  left: 15%;
+  top: 18%;
+  width: 220px;
+}
+
+.blob-two {
+  background: #ffab40;
+  bottom: 10%;
+  height: 320px;
+  right: 18%;
+  width: 320px;
+}
+
+.visual-glyph {
+  color: rgba(121, 85, 72, 0.35);
+  font-size: clamp(6rem, 18vw, 12rem);
+  left: 50%;
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%) rotate(-12deg);
+}
+
+.onboarding-card {
+  background: var(--light);
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  box-shadow: 0 -20px 45px rgba(0, 0, 0, 0.08);
+  padding: clamp(1.5rem, 5vw, 3rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.onboarding-slide {
+  display: grid;
+  gap: 1.2rem;
+  text-align: center;
+}
+
+.onboarding-slide .slide-visual {
+  align-items: center;
+  background: linear-gradient(135deg, rgba(245, 124, 0, 0.15), rgba(251, 192, 45, 0.4));
+  border-radius: 32px;
+  color: #f57c00;
+  display: inline-flex;
+  font-size: clamp(3rem, 12vw, 5rem);
+  height: clamp(120px, 22vw, 160px);
+  justify-content: center;
+  margin: 0 auto;
+  width: clamp(160px, 40vw, 220px);
+}
+
+.onboarding-slide .slide-visual.accent-growth {
+  background: linear-gradient(135deg, rgba(76, 175, 80, 0.2), rgba(129, 199, 132, 0.45));
+  color: #2e7d32;
+}
+
+.onboarding-slide .slide-visual.accent-price {
+  background: linear-gradient(135deg, rgba(255, 152, 0, 0.2), rgba(255, 204, 128, 0.55));
+  color: #ef6c00;
+}
+
+.onboarding-slide h2 {
+  font-size: clamp(1.8rem, 3vw, 2.7rem);
+  font-weight: 600;
+}
+
+.onboarding-slide p {
+  font-size: clamp(1rem, 2.4vw, 1.3rem);
+  color: rgba(31, 31, 31, 0.7);
+  line-height: 1.6;
+}
+
+.progress-wrapper {
+  display: flex;
+  justify-content: center;
+}
+
+.progress-bar {
+  background: rgba(0, 0, 0, 0.08);
+  border-radius: 999px;
+  height: 8px;
+  overflow: hidden;
+  width: min(340px, 90%);
+}
+
+.progress-indicator {
+  background: linear-gradient(90deg, #f79f1f, #f7c04a);
+  height: 100%;
+  transition: width var(--transition);
+  width: 0;
+}
+
+.onboarding-actions {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.btn {
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 600;
+  padding: 0.9rem 1.2rem;
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.btn:focus-visible {
+  outline: 3px solid rgba(247, 159, 31, 0.5);
+  outline-offset: 2px;
+}
+
+.btn.primary {
+  background: linear-gradient(120deg, #fcd45d, #f79f1f);
+  color: var(--dark);
+  box-shadow: 0 12px 24px rgba(247, 159, 31, 0.2);
+}
+
+.btn.primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 34px rgba(247, 159, 31, 0.25);
+}
+
+.btn.ghost {
+  background: transparent;
+  color: var(--orange);
+}
+
+.btn.ghost:hover {
+  transform: translateY(-2px);
+}
+
+.btn.outlined {
+  background: transparent;
+  border: 2px solid rgba(247, 159, 31, 0.6);
+  color: var(--dark);
+}
+
+.home {
+  align-items: center;
+  background: var(--muted-yellow);
+  flex-direction: column;
+  gap: 2rem;
+  padding: clamp(2rem, 4vw, 4rem) 1.5rem;
+}
+
+.home-header {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: clamp(1rem, 5vw, 5rem);
+  text-align: center;
+}
+
+.home-header h1 {
+  font-size: clamp(1.8rem, 4vw, 2.5rem);
+  font-weight: 600;
+  max-width: 560px;
+}
+
+.brand-title {
+  background: linear-gradient(135deg, #f57c00, #ef6c00, #fbc02d);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  font-size: clamp(2rem, 6vw, 3.6rem);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.scan-options {
+  background: rgba(255, 255, 255, 0.55);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 30px 45px rgba(0, 0, 0, 0.12);
+  display: grid;
+  gap: 1rem;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  width: min(680px, 100%);
+}
+
+.scan-option {
+  align-items: center;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  display: flex;
+  gap: 1.2rem;
+  padding: 1.1rem 1.3rem;
+  text-align: left;
+  transition: background var(--transition), transform var(--transition), box-shadow var(--transition);
+}
+
+.scan-option:hover {
+  background: rgba(247, 159, 31, 0.12);
+  transform: translateY(-2px);
+  box-shadow: 0 16px 30px rgba(0, 0, 0, 0.08);
+}
+
+.scan-option .scan-icon {
+  align-items: center;
+  background: linear-gradient(135deg, rgba(245, 124, 0, 0.12), rgba(251, 192, 45, 0.4));
+  border-radius: 20px;
+  color: #f57c00;
+  display: inline-flex;
+  font-size: clamp(1.8rem, 4vw, 2.3rem);
+  height: clamp(52px, 9vw, 64px);
+  justify-content: center;
+  width: clamp(52px, 9vw, 64px);
+}
+
+.scan-icon.upload::before {
+  content: "⬆️";
+}
+
+.scan-icon.camera::before {
+  content: "📷";
+}
+
+.scan-option h2 {
+  font-size: clamp(1.2rem, 2.8vw, 1.5rem);
+}
+
+.scan-option p {
+  color: rgba(31, 31, 31, 0.7);
+  font-size: clamp(0.95rem, 2.4vw, 1.05rem);
+  line-height: 1.5;
+  margin-top: 0.35rem;
+}
+
+.result {
+  align-items: center;
+  background: var(--muted-yellow);
+  flex-direction: column;
+  gap: 2rem;
+  padding: clamp(2rem, 5vw, 4rem) 1.5rem clamp(3rem, 5vw, 5rem);
+}
+
+.result-card {
+  background: var(--light);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 40px 60px rgba(0, 0, 0, 0.15);
+  display: grid;
+  gap: 1.5rem;
+  max-width: 720px;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  width: min(720px, 100%);
+}
+
+.result-image {
+  background: rgba(247, 159, 31, 0.1);
+  border-radius: var(--radius-md);
+  max-height: 320px;
+  overflow: hidden;
+}
+
+.result-image img {
+  height: 100%;
+  object-fit: contain;
+  width: 100%;
+}
+
+.result-details {
+  display: grid;
+  gap: 1rem;
+}
+
+.result-details dt {
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.result-details dd {
+  font-size: clamp(1.1rem, 2.4vw, 1.4rem);
+  font-weight: 500;
+}
+
+.confidence {
+  align-items: center;
+  display: flex;
+  gap: 1rem;
+}
+
+.result-error {
+  background: rgba(220, 53, 69, 0.1);
+  border-left: 4px solid #dc3545;
+  border-radius: 0 12px 12px 0;
+  color: #8a1c26;
+  padding: 0.75rem 1rem;
+}
+
+.result-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: min(420px, 100%);
+}
+
+.toast {
+  background: rgba(31, 31, 31, 0.9);
+  border-radius: var(--radius-sm);
+  color: var(--light);
+  left: 50%;
+  padding: 0.75rem 1.1rem;
+  position: fixed;
+  top: 1.5rem;
+  transform: translateX(-50%);
+  z-index: 1200;
+}
+
+.loading {
+  align-items: center;
+  backdrop-filter: blur(4px);
+  background: rgba(255, 241, 208, 0.6);
+  display: grid;
+  inset: 0;
+  justify-items: center;
+  position: fixed;
+  z-index: 1100;
+}
+
+.spinner {
+  animation: spin 1s linear infinite;
+  border: 4px solid rgba(247, 159, 31, 0.3);
+  border-radius: 50%;
+  border-top-color: #f79f1f;
+  height: 54px;
+  width: 54px;
+}
+
+.loading p {
+  font-size: 1.1rem;
+  font-weight: 500;
+  margin-top: 1rem;
+}
+
+.sr-only {
+  border: 0 !important;
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute !important;
+  width: 1px;
+  white-space: nowrap;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (min-width: 960px) {
+  .onboarding {
+    flex-direction: row;
+  }
+
+  .onboarding-visual {
+    flex: 1 1 50%;
+  }
+
+  .onboarding-card {
+    border-radius: 0;
+    flex: 1 1 50%;
+    justify-content: center;
+  }
+
+  .onboarding-actions {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .result-actions {
+    flex-direction: row;
+    justify-content: center;
+  }
+
+  .result-actions .btn {
+    flex: 1 1 auto;
+  }
+}


### PR DESCRIPTION
## Summary
- rebuild the splash, onboarding, and scan option visuals with CSS-driven elements so the web app no longer depends on binary image assets
- add an SVG Mangosoft icon and update the manifest and service worker cache list to reference the new vector asset

## Testing
- python -m http.server 4173

------
https://chatgpt.com/codex/tasks/task_e_68e61c6b3a00832cb3da0fcaf4218397