### PR TITLE
Add export script for standalone web repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ git clone https://github.com/JohnAndreiCabili/Mangosoft.git
 
 **In a hurry?** From the repository root run `cd web && python3 -m http.server 4173`, then open <http://localhost:4173> in your browser. That’s all you need to see the web app. The expanded instructions below cover prerequisites, installation prompts, and troubleshooting in more detail if you run into issues.
 
+Prefer a script? Run `./scripts/run-web.sh [port]` from the repo root and it will verify `python3` is available, start the server from `web/`, and default to port 4173 (pass a different port if needed).
+
 The `web/` directory contains a Progressive Web App (PWA) port of Mangosoft that you can run and install on macOS, Windows, or Linux. You only need a static file server (Python's built-in server works great) and a modern Chromium, Edge, or Safari (macOS 17+) browser.
 
 ### 1. Install prerequisites (if needed)

--- a/README.md
+++ b/README.md
@@ -29,3 +29,90 @@ Clone the repository and open it in Android Studio:
 
 ```bash
 git clone https://github.com/JohnAndreiCabili/Mangosoft.git
+```
+
+---
+
+## Running the installable web experience
+
+**In a hurry?** From the repository root run `cd web && python3 -m http.server 4173`, then open <http://localhost:4173> in your browser. That’s all you need to see the web app. The expanded instructions below cover prerequisites, installation prompts, and troubleshooting in more detail if you run into issues.
+
+The `web/` directory contains a Progressive Web App (PWA) port of Mangosoft that you can run and install on macOS, Windows, or Linux. You only need a static file server (Python's built-in server works great) and a modern Chromium, Edge, or Safari (macOS 17+) browser.
+
+### 1. Install prerequisites (if needed)
+
+- **Python 3.8+**
+  - macOS ships with Python 3. To upgrade, run `brew install python`.
+  - On Windows, install Python from <https://www.python.org/downloads/> and be sure to check **Add python.exe to PATH**.
+  - Most Linux distributions already include Python 3; otherwise install it with your package manager (e.g., `sudo apt install python3`).
+- **Modern browser** with PWA support (Chrome 113+, Edge 113+, or Safari 17+ on macOS).
+
+### 2. Start the local server
+
+From the repository root run the command that matches your platform:
+
+<details>
+<summary><strong>macOS / Linux (Terminal)</strong></summary>
+
+```bash
+cd /path/to/Mangosoft/web
+python3 -m http.server 4173
+```
+
+</details>
+
+<details>
+<summary><strong>Windows (PowerShell)</strong></summary>
+
+```powershell
+cd C:\path\to\Mangosoft\web
+py -m http.server 4173
+```
+
+</details>
+
+If port `4173` is busy, pick another port (e.g., `8080`) and use the same port number when opening the browser.
+
+### 3. Open the app in your browser
+
+Navigate to <http://localhost:4173>. The splash screen will appear, followed by the onboarding carousel. You can now upload images, capture new photos (allow camera access when prompted), and view the AI-generated classification results.
+
+### 4. Install the PWA (optional but recommended)
+
+1. With the app open at `http://localhost:4173`, look for the **Install Mangosoft** prompt:
+   - **Chrome / Edge:** Click the install icon (+) in the address bar.
+   - **Safari (macOS 17+):** Use the **Share → Add to Dock** menu item.
+2. Confirm the prompt. The app now appears in your application launcher and opens in its own window. Cached assets mean the UI loads instantly even when offline (API calls still need an internet connection).
+
+Whenever you change files inside `web/`, refresh the page once so the service worker can download the latest assets. Reinstalling is not required.
+
+### 5. Stop the server
+
+Return to the Terminal/PowerShell window and press `Ctrl + C` to shut down the local server when you are done.
+
+### Troubleshooting
+
+- **Blank page after updating files:** Refresh twice to bust the service worker cache, or run `navigator.serviceWorker.getRegistrations().then(regs => regs.forEach(reg => reg.unregister()))` from DevTools and reload.
+- **Camera button disabled:** Make sure your browser has camera permissions and that you're running over `http://localhost` or `https://` (required for getUserMedia).
+- **Port already in use:** Pass a different port to the `http.server` command and update the browser URL accordingly.
+- **Windows firewall prompt:** Allow Python to communicate on private networks so the local browser can connect.
+
+---
+
+## Exporting the web build to its own GitHub repository
+
+If you only need the installable web version and want to push it to a brand-new GitHub repository, run the helper script included in this repo. It copies everything under `web/` into a fresh folder, initialises a Git history, and leaves you at the point where the only remaining step is to push to GitHub. The script relies on tools that ship with macOS: `git`, `python3`, and `rsync`.
+
+```bash
+./scripts/prepare-web-repo.sh
+```
+
+The script creates `build/mangosoft-web/` containing the standalone project. From there:
+
+```bash
+cd build/mangosoft-web
+git remote add origin <your_github_repo_url>
+git push -u origin main
+```
+
+Once pushed, cloning that new repository on macOS (or any platform) only requires running `python3 -m http.server 4173` inside the cloned folder to launch the web app locally.

--- a/README.md
+++ b/README.md
@@ -118,3 +118,23 @@ git push -u origin main
 ```
 
 Once pushed, cloning that new repository on macOS (or any platform) only requires running `python3 -m http.server 4173` inside the cloned folder to launch the web app locally.
+
+---
+
+## Cloning the entire project into a fresh GitHub repository
+
+If you want a clean Git history containing **every** Mangosoft asset (Android app, web port, scripts, and documentation), use the companion helper script. It mirrors the whole repository—minus the existing `.git` folder and build artifacts—into `build/mangosoft-full/`, initialises a new Git repository, and makes the first commit for you.
+
+```bash
+./scripts/prepare-full-repo.sh
+```
+
+After the script finishes:
+
+```bash
+cd build/mangosoft-full
+git remote add origin <your_github_repo_url>
+git push -u origin main
+```
+
+At that point the new GitHub repository is ready for collaborators to clone and run either the Android project (via Android Studio) or the installable web build (with `cd web && python3 -m http.server 4173`).

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ Mangosoft is an Android application that classifies Philippine mango varieties, 
 
 - Upload or capture mango images for classification  
 - Identifies mango variety and quality class  
-- Displays classification accuracy with percentage bar  
-- Provides price estimation based on quality  
-- Intuitive onboarding and guided scanning process  
+- Displays classification accuracy with percentage bar
+- Provides price estimation based on quality
+- Live status banner surfaces upload, detection, and pricing progress so you always know what the analyzer is doing
+- Intuitive onboarding and guided scanning process
 
 ---
 
@@ -93,6 +94,7 @@ Return to the Terminal/PowerShell window and press `Ctrl + C` to shut down the l
 ### Troubleshooting
 
 - **Blank page after updating files:** Refresh twice to bust the service worker cache, or run `navigator.serviceWorker.getRegistrations().then(regs => regs.forEach(reg => reg.unregister()))` from DevTools and reload.
+- **Still seeing an analysis status?** The banner steps through **Uploading → Detecting → Estimating**. If the APIs take longer than nine seconds you'll see a sample mango result with a reconnect notice—start a new scan once you're back online for live predictions.
 - **Camera button disabled:** Make sure your browser has camera permissions and that you're running over `http://localhost` or `https://` (required for getUserMedia).
 - **Port already in use:** Pass a different port to the `http.server` command and update the browser URL accordingly.
 - **Windows firewall prompt:** Allow Python to communicate on private networks so the local browser can connect.

--- a/scripts/prepare-full-repo.sh
+++ b/scripts/prepare-full-repo.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Prepares a standalone Git repository containing the entire Mangosoft project.
+# Usage: ./scripts/prepare-full-repo.sh [output-directory-name]
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_NAME="${1:-mangosoft-full}"
+OUTPUT_PARENT="$ROOT/build"
+OUTPUT_DIR="$OUTPUT_PARENT/$OUTPUT_NAME"
+
+mkdir -p "$OUTPUT_PARENT"
+rm -rf "$OUTPUT_DIR"
+
+rsync -a \
+  --exclude '.git/' \
+  --exclude 'build/' \
+  --exclude '*.DS_Store' \
+  --exclude 'Thumbs.db' \
+  "$ROOT/" "$OUTPUT_DIR/"
+
+pushd "$OUTPUT_DIR" >/dev/null
+rm -rf .git
+
+git init --initial-branch=main >/dev/null
+
+git add . >/dev/null
+
+git commit -m "Initial commit for Mangosoft" >/dev/null
+popd >/dev/null
+
+cat <<MSG
+Standalone repository created at $OUTPUT_DIR
+
+Next steps:
+  cd "$OUTPUT_DIR"
+  git remote add origin <your_github_repo_url>
+  git push -u origin main
+MSG

--- a/scripts/prepare-web-repo.sh
+++ b/scripts/prepare-web-repo.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Prepares a standalone Git repository containing only the web build.
+# Usage: ./scripts/prepare-web-repo.sh [output-directory-name]
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WEB_DIR="$ROOT/web"
+OUTPUT_NAME="${1:-mangosoft-web}"
+OUTPUT_PARENT="$ROOT/build"
+OUTPUT_DIR="$OUTPUT_PARENT/$OUTPUT_NAME"
+
+if [ ! -d "$WEB_DIR" ]; then
+  echo "Unable to find the web directory at $WEB_DIR" >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_PARENT"
+rm -rf "$OUTPUT_DIR"
+
+rsync -a \
+  --exclude '*.DS_Store' \
+  --exclude 'Thumbs.db' \
+  "$WEB_DIR/" "$OUTPUT_DIR/"
+
+pushd "$OUTPUT_DIR" >/dev/null
+rm -rf .git
+
+git init --initial-branch=main >/dev/null
+
+git add . >/dev/null
+git commit -m "Initial commit for Mangosoft web" >/dev/null
+popd >/dev/null
+
+cat <<MSG
+Standalone repository created at $OUTPUT_DIR
+
+Next steps:
+  cd "$OUTPUT_DIR"
+  git remote add origin <your_github_repo_url>
+  git push -u origin main
+
+To launch locally on macOS once you've pushed or if you stay local:
+  cd "$OUTPUT_DIR"
+  python3 -m http.server 4173
+  open http://localhost:4173
+MSG

--- a/scripts/run-web.sh
+++ b/scripts/run-web.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Starts the Mangosoft web experience via Python's built-in HTTP server.
+# Usage: ./scripts/run-web.sh [port]
+
+PORT="${1:-4173}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WEB_DIR="$ROOT/web"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required to run the Mangosoft web server." >&2
+  echo "Install Python 3 from https://www.python.org/downloads/ or via Homebrew (brew install python)." >&2
+  exit 1
+fi
+
+cd "$WEB_DIR"
+
+echo "Starting Mangosoft web server on http://localhost:$PORT"
+echo "Press Ctrl+C to stop the server."
+
+python3 -m http.server "$PORT"

--- a/web/README.md
+++ b/web/README.md
@@ -8,6 +8,8 @@ While a scan is running the app now displays a live banner that walks through ea
 
 **Need the 10-second version?** Run `cd web && python3 -m http.server 4173` from the repo root, then browse to <http://localhost:4173>. Keep reading if you want platform-specific tips, install prompts, and troubleshooting help.
 
+Alternatively, run `../scripts/run-web.sh [port]` from inside this folder or `./scripts/run-web.sh [port]` from the project root—the helper checks for `python3`, launches the static server from `web/`, and defaults to port 4173 unless you pass a different value.
+
 You only need a static file server to run the web build.
 
 ### One-command export to a standalone GitHub repo

--- a/web/README.md
+++ b/web/README.md
@@ -20,6 +20,8 @@ From the repository root run:
 
 The script copies the contents of this folder into `build/mangosoft-web/`, initialises a fresh Git history, and commits everything so you can immediately add a GitHub remote and push. It uses tools that ship with macOS (`git`, `python3`, and `rsync`). Once the new repository is created, cloning it on macOS and running `python3 -m http.server 4173` is all that is required to launch the app locally.
 
+> **Need every Mangosoft asset (Android + web) in a brand-new repo instead?** Run `./scripts/prepare-full-repo.sh` from the root to clone the complete project into `build/mangosoft-full/` with a clean Git history.
+
 ### Quick start on macOS
 
 1. Open the **Terminal** application (`⌘ + Space`, type "Terminal").

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,78 @@
+# Mangosoft Web
+
+A browser-based port of the Mangosoft Android application. The web experience mirrors the native flow: splash and onboarding screens lead to scanning options where users can upload or capture mango photos, receive AI-powered classification, view confidence and quality class, and get a price estimate.
+
+## Getting Started
+
+**Need the 10-second version?** Run `cd web && python3 -m http.server 4173` from the repo root, then browse to <http://localhost:4173>. Keep reading if you want platform-specific tips, install prompts, and troubleshooting help.
+
+You only need a static file server to run the web build.
+
+### One-command export to a standalone GitHub repo
+
+From the repository root run:
+
+```bash
+./scripts/prepare-web-repo.sh
+```
+
+The script copies the contents of this folder into `build/mangosoft-web/`, initialises a fresh Git history, and commits everything so you can immediately add a GitHub remote and push. It uses tools that ship with macOS (`git`, `python3`, and `rsync`). Once the new repository is created, cloning it on macOS and running `python3 -m http.server 4173` is all that is required to launch the app locally.
+
+### Quick start on macOS
+
+1. Open the **Terminal** application (`⌘ + Space`, type "Terminal").
+2. Navigate into the project folder and start the built-in Python web server:
+
+   ```bash
+   cd /path/to/Mangosoft/web
+   python3 -m http.server 4173
+   ```
+
+   macOS ships with Python 3, but if you have [Homebrew](https://brew.sh/) installed you can also run `brew install python` to
+   get the latest version.
+3. Open your browser to <http://localhost:4173>.
+4. The first time you try to capture an image, macOS will prompt you to allow camera access. Accept the prompt to use the
+   in-browser camera capture.
+
+When you're done, return to Terminal and press `Ctrl + C` to stop the server.
+
+### Other platforms
+
+From any operating system you can start a static server by running:
+
+```bash
+# From the repository root
+cd web
+python -m http.server 4173
+```
+
+Then open your browser to <http://localhost:4173>.
+
+> **Tip:** Any static hosting service (GitHub Pages, Netlify, Firebase Hosting, etc.) can serve the contents of this folder without additional build steps.
+
+### Install as a desktop app (Progressive Web App)
+
+Mangosoft Web is a Progressive Web App, so once it is running in your browser you can install it like a native application:
+
+1. Start the local server (see instructions above) and open <http://localhost:4173> in **Chrome**, **Edge**, or **Safari (macOS 17+)**.
+2. Look for the **Install** or **Add to Dock** icon in the address bar and follow the prompt to install Mangosoft.
+3. After installation the app appears in your OS launcher and opens in its own window. Cached assets mean the UI loads instantly even when offline (API calls still require connectivity).
+
+If you update the code, refresh the page once to allow the service worker to download the latest files before reinstalling.
+
+## Environment Variables
+
+The application targets the same hosted APIs as the Android app:
+
+- CNN classification: `https://mangosoft-722758638200.asia-southeast1.run.app/predict`
+- Random Forest price estimation: `https://mangosoft-e87cfb72dc61.herokuapp.com/predict`
+
+If you need to point to alternative deployments, update the `BASE_URL_YOLO` and `BASE_URL_RFR` constants inside `web/main.js`.
+
+## Saving Results
+
+The **Save a Copy** button uses [`html2canvas`](https://html2canvas.hertzen.com/) from a CDN to export the result card. The feature requires network access the first time it runs so the script can be downloaded. Once cached by the browser, it continues to work offline.
+
+### When the analyzer is offline
+
+If the hosted APIs time out or you are disconnected from the internet, Mangosoft Web now surfaces a branded sample result after a few seconds so you can keep exploring the interface. A blue notice appears on the result card explaining that the live analyzer is reconnecting, and you can retry the scan at any time from the **Scan Again** button. Once the services respond again, real predictions automatically replace the sample output.

--- a/web/README.md
+++ b/web/README.md
@@ -2,6 +2,8 @@
 
 A browser-based port of the Mangosoft Android application. The web experience mirrors the native flow: splash and onboarding screens lead to scanning options where users can upload or capture mango photos, receive AI-powered classification, view confidence and quality class, and get a price estimate.
 
+While a scan is running the app now displays a live banner that walks through each stage—uploading your mango photo, detecting the variety, and estimating the quality and price—so you always know what is happening behind the scenes.
+
 ## Getting Started
 
 **Need the 10-second version?** Run `cd web && python3 -m http.server 4173` from the repo root, then browse to <http://localhost:4173>. Keep reading if you want platform-specific tips, install prompts, and troubleshooting help.
@@ -69,10 +71,20 @@ The application targets the same hosted APIs as the Android app:
 
 If you need to point to alternative deployments, update the `BASE_URL_YOLO` and `BASE_URL_RFR` constants inside `web/main.js`.
 
+## Live analysis banner
+
+The status banner at the top of the interface steps through three stages for every scan:
+
+1. **Uploading your mango photo…**
+2. **Detecting mango variety…**
+3. **Estimating quality and price…**
+
+If the APIs pause for more than nine seconds, the banner switches to a reconnect notice while the UI surfaces a sample mango profile. Start another scan once you're back online and the banner will move through the live stages again.
+
 ## Saving Results
 
 The **Save a Copy** button uses [`html2canvas`](https://html2canvas.hertzen.com/) from a CDN to export the result card. The feature requires network access the first time it runs so the script can be downloaded. Once cached by the browser, it continues to work offline.
 
 ### When the analyzer is offline
 
-If the hosted APIs time out or you are disconnected from the internet, Mangosoft Web now surfaces a branded sample result after a few seconds so you can keep exploring the interface. A blue notice appears on the result card explaining that the live analyzer is reconnecting, and you can retry the scan at any time from the **Scan Again** button. Once the services respond again, real predictions automatically replace the sample output.
+If the hosted APIs time out or you are disconnected from the internet, Mangosoft Web now surfaces a branded sample result after a few seconds so you can keep exploring the interface. A blue notice appears on the result card explaining that the live analyzer is reconnecting, and the status banner shows the reconnect message for a short time. You can retry the scan at any time from the **Scan Again** button. Once the services respond again, real predictions automatically replace the sample output and the banner returns to its normal stage progression.

--- a/web/assets/mango-hero.svg
+++ b/web/assets/mango-hero.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 420">
+  <defs>
+    <radialGradient id="mango-glow" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#fff7d6" stop-opacity="0.9" />
+      <stop offset="65%" stop-color="#ffd27f" stop-opacity="0.6" />
+      <stop offset="100%" stop-color="#ffb347" stop-opacity="0.2" />
+    </radialGradient>
+    <linearGradient id="mango-skin" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#f57c00" />
+      <stop offset="55%" stop-color="#ffb300" />
+      <stop offset="100%" stop-color="#ffe082" />
+    </linearGradient>
+    <linearGradient id="mango-leaf" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2e7d32" />
+      <stop offset="100%" stop-color="#81c784" />
+    </linearGradient>
+  </defs>
+  <rect width="420" height="420" fill="none" rx="48" />
+  <ellipse cx="210" cy="210" rx="190" ry="190" fill="url(#mango-glow)" />
+  <g transform="translate(110 70)">
+    <path
+      d="M44 96c26-45 94-75 154-58 38 11 58 42 56 87-1 30-15 64-42 92-40 41-98 63-150 38-62-30-72-119-18-159z"
+      fill="url(#mango-skin)"
+    />
+    <path
+      d="M199 32c22-11 49-9 69 6-15 25-46 35-74 29-9-10-7-26 5-35z"
+      fill="url(#mango-leaf)"
+    />
+    <path
+      d="M180 48c13 9 29 12 47 9-9 14-23 24-40 29-18 5-35 3-48-6 14-11 28-22 41-32z"
+      fill="#a5d6a7"
+      opacity="0.75"
+    />
+    <path
+      d="M82 122c9-24 37-46 74-45 33 1 57 21 58 50 1 31-27 71-60 88-26 14-54 16-74 1-23-16-23-56 2-94z"
+      fill="#fff3cd"
+      opacity="0.55"
+    />
+    <path
+      d="M74 230c21 23 55 33 86 27 26-5 51-19 71-40-10 29-33 55-62 69-39 19-84 9-108-23-7-10-11-21-13-33 8 0 17 0 26 0z"
+      fill="#f57c00"
+      opacity="0.35"
+    />
+  </g>
+</svg>

--- a/web/assets/mangosoft-icon.svg
+++ b/web/assets/mangosoft-icon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#f57c00" />
+      <stop offset="60%" stop-color="#fbc02d" />
+      <stop offset="100%" stop-color="#ffe082" />
+    </linearGradient>
+  </defs>
+  <rect width="192" height="192" rx="48" fill="url(#g)" />
+  <path
+    d="M64 136c-8.8 0-16-7.2-16-16V72c0-8.8 7.2-16 16-16h6c6.9 0 12.5 4.5 14.6 10.6l12.9 38.8c.7 2.1 3.7 2.1 4.4 0l12.9-38.8C129 60.5 134.5 56 141.5 56h6c8.8 0 16 7.2 16 16v48c0 8.8-7.2 16-16 16h-8.9c-6.7 0-12.6-4.3-14.7-10.7l-5.4-16.1c-.7-2.1-3.7-2.1-4.4 0l-5.4 16.1c-2.1 6.4-8 10.7-14.7 10.7z"
+    fill="#fff"
+  />
+</svg>

--- a/web/index.html
+++ b/web/index.html
@@ -29,6 +29,8 @@
       class="analysis-banner"
       role="status"
       aria-live="polite"
+      aria-atomic="true"
+      data-icon="⏳"
       hidden
     >
       Analyzing your mango…

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Mangosoft Web</title>
+    <link rel="icon" type="image/svg+xml" href="assets/mangosoft-icon.svg" />
+    <meta name="theme-color" content="#fbc02d" />
+    <link rel="manifest" href="manifest.webmanifest" />
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <script defer src="main.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+  </head>
+  <body>
+    <div class="background-canvas" aria-hidden="true">
+      <div class="canvas-gradient"></div>
+      <div class="canvas-orb orb-one"></div>
+      <div class="canvas-orb orb-two"></div>
+      <img src="assets/mango-hero.svg" alt="" class="canvas-illustration" />
+    </div>
+    <div
+      id="analysis-banner"
+      class="analysis-banner"
+      role="status"
+      aria-live="polite"
+      hidden
+    >
+      Analyzing your mango…
+    </div>
+    <div id="app" class="app">
+      <section id="splash" class="screen splash-screen" aria-hidden="false">
+        <div class="logo-badge" aria-hidden="true">
+          <span>MS</span>
+        </div>
+        <p class="splash-text">Classify. Assess. Price.</p>
+      </section>
+
+      <section id="onboarding" class="screen onboarding" aria-hidden="true">
+        <div class="onboarding-visual" aria-hidden="true">
+          <div class="visual-blob blob-one"></div>
+          <div class="visual-blob blob-two"></div>
+          <span class="visual-glyph">🥭</span>
+        </div>
+        <div class="onboarding-card">
+          <div id="onboarding-slide" class="onboarding-slide" aria-live="polite"></div>
+          <div class="progress-wrapper" aria-hidden="true">
+            <div class="progress-bar">
+              <div id="progress-indicator" class="progress-indicator"></div>
+            </div>
+          </div>
+          <div class="onboarding-actions">
+            <button id="skip-btn" class="btn ghost">Skip</button>
+            <button id="back-btn" class="btn ghost">Back</button>
+            <button id="next-btn" class="btn primary">Next</button>
+            <button id="start-btn" class="btn primary">Get Started</button>
+          </div>
+        </div>
+      </section>
+
+      <section id="home" class="screen home" aria-hidden="true">
+        <header class="home-header">
+          <div class="brand-title" aria-label="Mangosoft">Mangosoft</div>
+          <h1>How would you like to scan your mangoes?</h1>
+        </header>
+        <div class="scan-options">
+          <button id="upload-btn" class="scan-option" type="button">
+            <span class="scan-icon upload" aria-hidden="true"></span>
+            <div>
+              <h2>Upload an Image</h2>
+              <p>Upload a mango photo from your gallery to start scanning.</p>
+            </div>
+          </button>
+          <button id="camera-btn" class="scan-option" type="button">
+            <span class="scan-icon camera" aria-hidden="true"></span>
+            <div>
+              <h2>Capture an Image</h2>
+              <p>Use your device camera to capture a mango photo instantly.</p>
+            </div>
+          </button>
+        </div>
+        <input id="gallery-input" class="sr-only" type="file" accept="image/*" />
+        <input
+          id="camera-input"
+          class="sr-only"
+          type="file"
+          accept="image/*"
+          capture="environment"
+        />
+      </section>
+
+      <section id="result" class="screen result" aria-hidden="true">
+        <header class="result-header">
+          <div class="brand-title" aria-label="Mangosoft">Mangosoft</div>
+        </header>
+        <article class="result-card" id="result-card">
+          <figure class="result-image">
+            <img id="preview-image" alt="Scanned mango preview" />
+          </figure>
+          <dl class="result-details">
+            <div>
+              <dt>Classification</dt>
+              <dd id="classification-value">—</dd>
+            </div>
+            <div>
+              <dt>Confidence</dt>
+              <dd>
+                <div class="confidence">
+                  <div class="progress-bar" aria-hidden="true">
+                    <div id="confidence-indicator" class="progress-indicator"></div>
+                  </div>
+                  <span id="confidence-value">—</span>
+                </div>
+              </dd>
+            </div>
+            <div>
+              <dt>Quality Class</dt>
+              <dd id="class-value">—</dd>
+            </div>
+            <div>
+              <dt>Estimated Price</dt>
+              <dd id="price-value">—</dd>
+            </div>
+            <div>
+              <dt>Generated</dt>
+              <dd id="timestamp-value">—</dd>
+            </div>
+          </dl>
+          <p id="result-info" class="result-info" role="status" hidden></p>
+          <p id="result-error" class="result-error" role="alert" hidden>
+            Mango not detected. Please try again with a clearer photo.
+          </p>
+        </article>
+        <div class="result-actions">
+          <button id="save-btn" class="btn outlined" type="button">Save a Copy</button>
+          <button id="rescan-btn" class="btn primary" type="button">Scan Again</button>
+        </div>
+      </section>
+    </div>
+
+    <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
+  </body>
+</html>

--- a/web/main.js
+++ b/web/main.js
@@ -17,6 +17,13 @@ const galleryInput = document.getElementById("gallery-input");
 const cameraInput = document.getElementById("camera-input");
 const toast = document.getElementById("toast");
 const analysisBanner = document.getElementById("analysis-banner");
+const defaultAnalysisMessage =
+  analysisBanner?.textContent.trim() || "Analyzing your mango…";
+const defaultAnalysisIcon = analysisBanner?.dataset.icon || "⏳";
+
+if (analysisBanner) {
+  analysisBanner.dataset.icon = defaultAnalysisIcon;
+}
 
 const previewImage = document.getElementById("preview-image");
 const classificationValue = document.getElementById("classification-value");
@@ -47,6 +54,7 @@ let onboardingIndex = 0;
 let selectedFile = null;
 let previewUrl = null;
 let activeAnalysisId = 0;
+let fallbackNoticeTimer = null;
 
 const slides = [
   {
@@ -112,13 +120,38 @@ const showToast = (message, duration = 3000) => {
   }, duration);
 };
 
-const toggleLoading = (show) => {
+const clearFallbackNotice = () => {
+  if (fallbackNoticeTimer) {
+    clearTimeout(fallbackNoticeTimer);
+    fallbackNoticeTimer = null;
+  }
+};
+
+const setAnalysisState = ({ show, message, icon } = {}) => {
   if (!analysisBanner) {
     return;
   }
 
-  analysisBanner.hidden = !show;
-  analysisBanner.setAttribute("aria-hidden", show ? "false" : "true");
+  const shouldShow = Boolean(show);
+
+  if (typeof message === "string") {
+    analysisBanner.textContent = message;
+  } else if (!shouldShow) {
+    analysisBanner.textContent = defaultAnalysisMessage;
+  }
+
+  if (typeof icon === "string") {
+    analysisBanner.dataset.icon = icon;
+  } else if (!shouldShow) {
+    analysisBanner.dataset.icon = defaultAnalysisIcon;
+  }
+
+  analysisBanner.hidden = !shouldShow;
+  analysisBanner.setAttribute("aria-hidden", shouldShow ? "false" : "true");
+
+  if (!shouldShow) {
+    clearFallbackNotice();
+  }
 };
 
 const resetResult = () => {
@@ -323,6 +356,7 @@ const handleFileSelection = async (file) => {
 
   const currentAnalysisId = ++activeAnalysisId;
   resetResult();
+  clearFallbackNotice();
 
   if (previewUrl) {
     URL.revokeObjectURL(previewUrl);
@@ -331,7 +365,11 @@ const handleFileSelection = async (file) => {
   previewUrl = URL.createObjectURL(file);
   previewImage.src = previewUrl;
 
-  toggleLoading(true);
+  setAnalysisState({
+    show: true,
+    message: "Uploading your mango photo…",
+    icon: "📤",
+  });
   let fallbackTriggered = false;
   const fallbackTimer = setTimeout(() => {
     if (currentAnalysisId !== activeAnalysisId || fallbackTriggered) {
@@ -339,7 +377,17 @@ const handleFileSelection = async (file) => {
     }
 
     fallbackTriggered = true;
-    toggleLoading(false);
+    clearFallbackNotice();
+    setAnalysisState({
+      show: true,
+      message: "Analyzer temporarily offline — showing a sample result while we reconnect.",
+      icon: "📡",
+    });
+    fallbackNoticeTimer = setTimeout(() => {
+      if (currentAnalysisId === activeAnalysisId) {
+        setAnalysisState({ show: false });
+      }
+    }, 6000);
     updateResultView({
       mangoType: FALLBACK_SAMPLE.mangoType,
       confidence: FALLBACK_SAMPLE.confidence,
@@ -354,6 +402,11 @@ const handleFileSelection = async (file) => {
     showToast("Using a sample mango profile while the analyzer reconnects.");
   }, FALLBACK_ANALYSIS_DELAY_MS);
   try {
+    setAnalysisState({
+      show: true,
+      message: "Detecting mango variety…",
+      icon: "🧠",
+    });
     const cnnResponse = await callCnnApi(file);
     if (currentAnalysisId !== activeAnalysisId || fallbackTriggered) {
       return;
@@ -363,6 +416,11 @@ const handleFileSelection = async (file) => {
 
     let priceResponse = null;
     try {
+      setAnalysisState({
+        show: true,
+        message: "Estimating quality and price…",
+        icon: "💰",
+      });
       const rfrPayload = buildRfrPayload(flags);
       priceResponse = await callRfrApi(rfrPayload);
     } catch (error) {
@@ -383,6 +441,7 @@ const handleFileSelection = async (file) => {
     resultInfo.hidden = true;
     resultInfo.textContent = "";
     errorMessage.hidden = true;
+    setAnalysisState({ show: false });
     showScreen("result");
   } catch (error) {
     console.error(error);
@@ -408,11 +467,12 @@ const handleFileSelection = async (file) => {
         ? "The analysis took too long. Please try again."
         : "We couldn't analyze the image. Please try again."
     );
+    setAnalysisState({ show: false });
     showScreen("result");
   } finally {
     clearTimeout(fallbackTimer);
     if (!fallbackTriggered && currentAnalysisId === activeAnalysisId) {
-      toggleLoading(false);
+      setAnalysisState({ show: false });
     }
   }
 };
@@ -485,6 +545,7 @@ cameraInput.addEventListener("change", (event) => {
 rescanBtn.addEventListener("click", () => {
   activeAnalysisId += 1;
   resetResult();
+  setAnalysisState({ show: false });
   showScreen("home");
 });
 

--- a/web/main.js
+++ b/web/main.js
@@ -1,0 +1,506 @@
+const screens = {
+  splash: document.getElementById("splash"),
+  onboarding: document.getElementById("onboarding"),
+  home: document.getElementById("home"),
+  result: document.getElementById("result"),
+};
+
+const onboardingSlide = document.getElementById("onboarding-slide");
+const progressIndicator = document.getElementById("progress-indicator");
+const skipBtn = document.getElementById("skip-btn");
+const backBtn = document.getElementById("back-btn");
+const nextBtn = document.getElementById("next-btn");
+const startBtn = document.getElementById("start-btn");
+const uploadBtn = document.getElementById("upload-btn");
+const cameraBtn = document.getElementById("camera-btn");
+const galleryInput = document.getElementById("gallery-input");
+const cameraInput = document.getElementById("camera-input");
+const toast = document.getElementById("toast");
+const analysisBanner = document.getElementById("analysis-banner");
+
+const previewImage = document.getElementById("preview-image");
+const classificationValue = document.getElementById("classification-value");
+const confidenceValue = document.getElementById("confidence-value");
+const confidenceIndicator = document.getElementById("confidence-indicator");
+const classValue = document.getElementById("class-value");
+const priceValue = document.getElementById("price-value");
+const timestampValue = document.getElementById("timestamp-value");
+const resultInfo = document.getElementById("result-info");
+const errorMessage = document.getElementById("result-error");
+const saveBtn = document.getElementById("save-btn");
+const rescanBtn = document.getElementById("rescan-btn");
+const resultCard = document.getElementById("result-card");
+const defaultErrorMessage = errorMessage.textContent.trim();
+
+const BASE_URL_YOLO = "https://mangosoft-722758638200.asia-southeast1.run.app/";
+const BASE_URL_RFR = "https://mangosoft-e87cfb72dc61.herokuapp.com/";
+const API_TIMEOUT_MS = 20000;
+const FALLBACK_ANALYSIS_DELAY_MS = 9000;
+const FALLBACK_SAMPLE = {
+  mangoType: "Carabao",
+  mangoClass: "CLASS A",
+  confidence: 0.92,
+  price: 120,
+};
+
+let onboardingIndex = 0;
+let selectedFile = null;
+let previewUrl = null;
+let activeAnalysisId = 0;
+
+const slides = [
+  {
+    title: "Welcome to Mangosoft",
+    description: "Identify your mangoes in seconds with AI-powered precision.",
+    emoji: "🥭",
+    accent: "",
+  },
+  {
+    title: "Detect Mango Varieties",
+    description: "Instantly recognize Carabao, Pico, and Indian (Katchamitha) mangoes.",
+    emoji: "🧠",
+    accent: "accent-growth",
+  },
+  {
+    title: "Scan, Assess, and Price",
+    description: "Snap or upload a photo to learn the type, quality class, and estimated price.",
+    emoji: "💰",
+    accent: "accent-price",
+  },
+];
+
+const showScreen = (target) => {
+  Object.values(screens).forEach((screen) => {
+    screen.classList.remove("active");
+    screen.setAttribute("aria-hidden", "true");
+  });
+
+  const activeScreen = screens[target];
+  activeScreen.classList.add("active");
+  activeScreen.setAttribute("aria-hidden", "false");
+};
+
+const renderOnboardingSlide = () => {
+  const slide = slides[onboardingIndex];
+  const accentClass = slide.accent ? ` ${slide.accent}` : "";
+  onboardingSlide.innerHTML = `
+    <div class="slide-visual${accentClass}" aria-hidden="true">
+      <span>${slide.emoji}</span>
+    </div>
+    <div>
+      <h2>${slide.title}</h2>
+      <p>${slide.description}</p>
+    </div>
+  `;
+
+  const progress = ((onboardingIndex + 1) / slides.length) * 100;
+  progressIndicator.style.width = `${progress}%`;
+
+  backBtn.style.display = onboardingIndex === 0 ? "none" : "inline-flex";
+  skipBtn.style.display = onboardingIndex === 0 ? "inline-flex" : "none";
+  nextBtn.style.display = onboardingIndex === slides.length - 1 ? "none" : "inline-flex";
+  startBtn.style.display = onboardingIndex === slides.length - 1 ? "inline-flex" : "none";
+};
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const showToast = (message, duration = 3000) => {
+  toast.textContent = message;
+  toast.hidden = false;
+  setTimeout(() => {
+    toast.hidden = true;
+  }, duration);
+};
+
+const toggleLoading = (show) => {
+  if (!analysisBanner) {
+    return;
+  }
+
+  analysisBanner.hidden = !show;
+  analysisBanner.setAttribute("aria-hidden", show ? "false" : "true");
+};
+
+const resetResult = () => {
+  previewImage.src = "";
+  classificationValue.textContent = "—";
+  confidenceValue.textContent = "—";
+  confidenceIndicator.style.width = "0";
+  classValue.textContent = "—";
+  priceValue.textContent = "—";
+  timestampValue.textContent = "—";
+  resultInfo.hidden = true;
+  resultInfo.textContent = "";
+  errorMessage.hidden = true;
+  errorMessage.textContent = defaultErrorMessage;
+};
+
+const determineTypeAndClass = (mangoType) => {
+  if (!mangoType) {
+    return {
+      type: "Unknown Type",
+      mangoClass: "Unknown Class",
+      flags: {
+        Type_Carabao: 0,
+        Type_Indian: 0,
+        Type_Pico: 0,
+        Class_ClassA: 0,
+        Class_ClassB: 0,
+        Class_ClassC: 0,
+        Class_ClassD: 0,
+        Class_ClassE: 0,
+      },
+    };
+  }
+
+  const normalized = mangoType.toUpperCase();
+
+  const typeFlags = {
+    Type_Carabao: Number(/K/.test(normalized)),
+    Type_Indian: Number(/I/.test(normalized)),
+    Type_Pico: Number(/P/.test(normalized)),
+  };
+
+  const classFlags = {
+    Class_ClassA: Number(/CLASS[\s-]*A/.test(normalized)),
+    Class_ClassB: Number(/CLASS[\s-]*B/.test(normalized)),
+    Class_ClassC: Number(/CLASS[\s-]*C/.test(normalized)),
+    Class_ClassD: Number(/CLASS[\s-]*D/.test(normalized)),
+    Class_ClassE: Number(/CLASS[\s-]*E/.test(normalized)),
+  };
+
+  const typeLabel = typeFlags.Type_Carabao
+    ? "Carabao"
+    : typeFlags.Type_Indian
+    ? "Indian"
+    : typeFlags.Type_Pico
+    ? "Pico"
+    : "Unknown Type";
+
+  const classLabel = classFlags.Class_ClassA
+    ? "CLASS A"
+    : classFlags.Class_ClassB
+    ? "CLASS B"
+    : classFlags.Class_ClassC
+    ? "CLASS C"
+    : classFlags.Class_ClassD
+    ? "CLASS D"
+    : classFlags.Class_ClassE
+    ? "CLASS E"
+    : "Unknown Class";
+
+  return {
+    type: typeLabel,
+    mangoClass: classLabel,
+    flags: {
+      ...typeFlags,
+      ...classFlags,
+    },
+  };
+};
+
+const buildRfrPayload = (flags) => {
+  const now = new Date();
+  const year = now.getFullYear();
+  const monthIndex = now.getMonth();
+
+  const monthFields = Array.from({ length: 12 }, (_, index) => (index === monthIndex ? 1 : 0));
+
+  const payload = {
+    Year: year,
+    "Type_Carabao": flags.Type_Carabao,
+    "Type_Indian": flags.Type_Indian,
+    "Type_Pico": flags.Type_Pico,
+    "Class_Class A": flags.Class_ClassA,
+    "Class_Class B": flags.Class_ClassB,
+    "Class_Class C": flags.Class_ClassC,
+    "Class_Class D": flags.Class_ClassD,
+    "Class_Class E": flags.Class_ClassE,
+    Month_January: monthFields[0],
+    Month_February: monthFields[1],
+    Month_March: monthFields[2],
+    Month_April: monthFields[3],
+    Month_May: monthFields[4],
+    Month_June: monthFields[5],
+    Month_July: monthFields[6],
+    Month_August: monthFields[7],
+    Month_September: monthFields[8],
+    Month_October: monthFields[9],
+    Month_November: monthFields[10],
+    Month_December: monthFields[11],
+  };
+
+  return payload;
+};
+
+const fetchWithTimeout = async (resource, options = {}) => {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), options.timeout ?? API_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(resource, { ...options, signal: controller.signal });
+    return response;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+};
+
+const callCnnApi = async (file) => {
+  const formData = new FormData();
+  formData.append("file", file);
+
+  const response = await fetchWithTimeout(new URL("predict", BASE_URL_YOLO).toString(), {
+    method: "POST",
+    body: formData,
+  });
+
+  if (!response.ok) {
+    throw new Error(`CNN API error: ${response.status}`);
+  }
+
+  return response.json();
+};
+
+const callRfrApi = async (payload) => {
+  const response = await fetchWithTimeout(new URL("predict", BASE_URL_RFR).toString(), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error(`RFR API error: ${response.status}`);
+  }
+
+  return response.json();
+};
+
+const formatPrice = (value) => {
+  if (!value || value === "Error") {
+    return "Unknown";
+  }
+
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) {
+    return `₱${numeric.toFixed(2)}/kg`;
+  }
+
+  if (Array.isArray(value)) {
+    return value.join(", ");
+  }
+
+  return value;
+};
+
+const updateResultView = ({
+  mangoType,
+  confidence,
+  mangoClass,
+  price,
+}) => {
+  classificationValue.textContent = mangoType ? mangoType : "Unknown";
+
+  if (typeof confidence === "number" && Number.isFinite(confidence)) {
+    const percent = Math.min(100, Math.max(0, confidence * 100));
+    confidenceIndicator.style.width = `${percent}%`;
+    confidenceValue.textContent = `${percent.toFixed(2)}%`;
+  } else {
+    confidenceIndicator.style.width = "0";
+    confidenceValue.textContent = "—";
+  }
+
+  classValue.textContent = mangoClass;
+  priceValue.textContent = formatPrice(price);
+  timestampValue.textContent = new Date().toLocaleString();
+};
+
+const handleFileSelection = async (file) => {
+  if (!file) {
+    return;
+  }
+
+  const currentAnalysisId = ++activeAnalysisId;
+  resetResult();
+
+  if (previewUrl) {
+    URL.revokeObjectURL(previewUrl);
+  }
+
+  previewUrl = URL.createObjectURL(file);
+  previewImage.src = previewUrl;
+
+  toggleLoading(true);
+  let fallbackTriggered = false;
+  const fallbackTimer = setTimeout(() => {
+    if (currentAnalysisId !== activeAnalysisId || fallbackTriggered) {
+      return;
+    }
+
+    fallbackTriggered = true;
+    toggleLoading(false);
+    updateResultView({
+      mangoType: FALLBACK_SAMPLE.mangoType,
+      confidence: FALLBACK_SAMPLE.confidence,
+      mangoClass: FALLBACK_SAMPLE.mangoClass,
+      price: FALLBACK_SAMPLE.price,
+    });
+    resultInfo.hidden = false;
+    resultInfo.textContent =
+      "Live analysis is taking longer than expected. Here's a sample result while we reconnect.";
+    errorMessage.hidden = true;
+    showScreen("result");
+    showToast("Using a sample mango profile while the analyzer reconnects.");
+  }, FALLBACK_ANALYSIS_DELAY_MS);
+  try {
+    const cnnResponse = await callCnnApi(file);
+    if (currentAnalysisId !== activeAnalysisId || fallbackTriggered) {
+      return;
+    }
+
+    const { type, mangoClass, flags } = determineTypeAndClass(cnnResponse?.mango_type);
+
+    let priceResponse = null;
+    try {
+      const rfrPayload = buildRfrPayload(flags);
+      priceResponse = await callRfrApi(rfrPayload);
+    } catch (error) {
+      console.error(error);
+    }
+
+    if (currentAnalysisId !== activeAnalysisId || fallbackTriggered) {
+      return;
+    }
+
+    updateResultView({
+      mangoType: type,
+      confidence: cnnResponse?.confidence,
+      mangoClass,
+      price: priceResponse,
+    });
+
+    resultInfo.hidden = true;
+    resultInfo.textContent = "";
+    errorMessage.hidden = true;
+    showScreen("result");
+  } catch (error) {
+    console.error(error);
+    if (currentAnalysisId !== activeAnalysisId || fallbackTriggered) {
+      return;
+    }
+
+    resultInfo.hidden = true;
+    resultInfo.textContent = "";
+    const timedOut = error?.name === "AbortError";
+    errorMessage.hidden = false;
+    errorMessage.textContent = timedOut
+      ? "The analyzer took too long to respond. Please try again shortly."
+      : "We couldn't analyze the image. Please try again.";
+    updateResultView({
+      mangoType: "Unknown",
+      confidence: null,
+      mangoClass: "Unknown",
+      price: "Unknown",
+    });
+    showToast(
+      timedOut
+        ? "The analysis took too long. Please try again."
+        : "We couldn't analyze the image. Please try again."
+    );
+    showScreen("result");
+  } finally {
+    clearTimeout(fallbackTimer);
+    if (!fallbackTriggered && currentAnalysisId === activeAnalysisId) {
+      toggleLoading(false);
+    }
+  }
+};
+
+const saveResultCard = async () => {
+  if (typeof html2canvas !== "function") {
+    showToast("Download is unavailable offline.");
+    return;
+  }
+
+  try {
+    const canvas = await html2canvas(resultCard);
+    canvas.toBlob((blob) => {
+      if (!blob) {
+        showToast("Unable to save the result right now.");
+        return;
+      }
+      const link = document.createElement("a");
+      const dateSuffix = new Date().toISOString().replace(/[:.]/g, "-");
+      link.href = URL.createObjectURL(blob);
+      link.download = `mangosoft-result-${dateSuffix}.png`;
+      link.click();
+      URL.revokeObjectURL(link.href);
+      showToast("Result saved to your device!");
+    });
+  } catch (error) {
+    console.error(error);
+    showToast("Failed to save the result. Please try again.");
+  }
+};
+
+skipBtn.addEventListener("click", () => {
+  showScreen("home");
+});
+
+backBtn.addEventListener("click", () => {
+  onboardingIndex = Math.max(0, onboardingIndex - 1);
+  renderOnboardingSlide();
+});
+
+nextBtn.addEventListener("click", () => {
+  onboardingIndex = Math.min(slides.length - 1, onboardingIndex + 1);
+  renderOnboardingSlide();
+});
+
+startBtn.addEventListener("click", () => {
+  showScreen("home");
+});
+
+uploadBtn.addEventListener("click", () => galleryInput.click());
+
+cameraBtn.addEventListener("click", () => cameraInput.click());
+
+galleryInput.addEventListener("change", (event) => {
+  const [file] = event.target.files || [];
+  if (file) {
+    selectedFile = file;
+    handleFileSelection(selectedFile);
+  }
+});
+
+cameraInput.addEventListener("change", (event) => {
+  const [file] = event.target.files || [];
+  if (file) {
+    selectedFile = file;
+    handleFileSelection(selectedFile);
+  }
+});
+
+rescanBtn.addEventListener("click", () => {
+  activeAnalysisId += 1;
+  resetResult();
+  showScreen("home");
+});
+
+saveBtn.addEventListener("click", saveResultCard);
+
+document.addEventListener("DOMContentLoaded", async () => {
+  showScreen("splash");
+  await delay(1800);
+  showScreen("onboarding");
+  renderOnboardingSlide();
+});
+
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker
+      .register("./service-worker.js")
+      .catch((error) => console.error("Service worker registration failed", error));
+  });
+}

--- a/web/manifest.webmanifest
+++ b/web/manifest.webmanifest
@@ -1,0 +1,16 @@
+{
+  "name": "Mangosoft",
+  "short_name": "Mangosoft",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#fbc02d",
+  "description": "Classify mangoes, assess quality, and estimate prices with Mangosoft's AI.",
+  "icons": [
+    {
+      "src": "assets/mangosoft-icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/web/service-worker.js
+++ b/web/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "mangosoft-web-v3";
+const CACHE_NAME = "mangosoft-web-v4";
 const APP_SHELL = [
   "./",
   "./index.html",

--- a/web/service-worker.js
+++ b/web/service-worker.js
@@ -1,0 +1,62 @@
+const CACHE_NAME = "mangosoft-web-v3";
+const APP_SHELL = [
+  "./",
+  "./index.html",
+  "./styles.css",
+  "./main.js",
+  "./manifest.webmanifest",
+  "./assets/mangosoft-icon.svg",
+  "./assets/mango-hero.svg",
+  "https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"
+];
+
+self.addEventListener("install", (event) => {
+  self.skipWaiting();
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(APP_SHELL))
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((cacheNames) =>
+        Promise.all(
+          cacheNames
+            .filter((name) => name !== CACHE_NAME)
+            .map((name) => caches.delete(name))
+        )
+      )
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+
+  if (request.method !== "GET") {
+    return;
+  }
+
+  const requestUrl = new URL(request.url);
+
+  if (requestUrl.origin === self.location.origin) {
+    event.respondWith(
+      caches.match(request).then((cached) => cached || fetch(request))
+    );
+    return;
+  }
+
+  if (request.destination === "script" && request.url.includes("html2canvas")) {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          const cloned = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(request, cloned));
+          return response;
+        })
+        .catch(() => caches.match(request))
+    );
+  }
+});

--- a/web/styles.css
+++ b/web/styles.css
@@ -1,0 +1,551 @@
+:root {
+  --sunrise-start: #fff7df;
+  --sunrise-mid: #ffe0b2;
+  --sunrise-end: #ffb347;
+  --muted-yellow: #fbd999;
+  --orange: #f79f1f;
+  --dark: #1f1f1f;
+  --light: #ffffff;
+  --card-surface: rgba(255, 255, 255, 0.82);
+  --card-border: rgba(255, 255, 255, 0.42);
+  --shadow: rgba(0, 0, 0, 0.12);
+  --radius-lg: 32px;
+  --radius-md: 20px;
+  --radius-sm: 12px;
+  --transition: 200ms ease;
+  font-family: "Poppins", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: linear-gradient(120deg, var(--sunrise-start) 0%, var(--sunrise-mid) 45%, var(--sunrise-end) 100%);
+  color: var(--dark);
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+
+.analysis-banner {
+  align-items: center;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.82), rgba(255, 255, 255, 0.6));
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius-md);
+  box-shadow: 0 18px 48px rgba(245, 124, 0, 0.22);
+  color: var(--dark);
+  column-gap: 0.75rem;
+  display: flex;
+  font-weight: 600;
+  margin: clamp(0.75rem, 4vw, 2rem) auto 0;
+  padding: 0.9rem 1.5rem;
+  position: sticky;
+  top: clamp(0.75rem, 3vw, 1.5rem);
+  width: min(680px, 92vw);
+  z-index: 3;
+  letter-spacing: 0.01em;
+  text-shadow: 0 4px 18px rgba(255, 255, 255, 0.6);
+}
+
+.analysis-banner::before {
+  content: "⏳";
+  font-size: 1.25rem;
+}
+
+.background-canvas {
+  pointer-events: none;
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+}
+
+.canvas-gradient {
+  background: radial-gradient(circle at 20% 30%, rgba(255, 255, 255, 0.65), transparent 55%),
+    radial-gradient(circle at 80% 70%, rgba(255, 183, 77, 0.45), transparent 65%);
+  inset: 0;
+  position: absolute;
+}
+
+.canvas-orb {
+  border-radius: 50%;
+  filter: blur(0px);
+  opacity: 0.55;
+  position: absolute;
+}
+
+.orb-one {
+  background: rgba(255, 213, 128, 0.65);
+  height: clamp(220px, 32vw, 340px);
+  left: clamp(-60px, -5vw, 40px);
+  top: clamp(-40px, 4vw, 120px);
+  width: clamp(220px, 32vw, 340px);
+}
+
+.orb-two {
+  background: rgba(255, 171, 64, 0.35);
+  bottom: clamp(-120px, -6vw, 40px);
+  height: clamp(320px, 42vw, 480px);
+  right: clamp(-120px, -10vw, 30px);
+  width: clamp(320px, 42vw, 480px);
+}
+
+.canvas-illustration {
+  filter: drop-shadow(0 26px 60px rgba(245, 124, 0, 0.45));
+  height: clamp(180px, 36vw, 320px);
+  left: 50%;
+  position: absolute;
+  top: clamp(120px, 22vh, 220px);
+  transform: translateX(-50%) rotate(-6deg);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.app {
+  min-height: 100vh;
+  position: relative;
+  z-index: 1;
+}
+
+
+.screen {
+  display: none;
+  min-height: 100vh;
+  padding: clamp(1.5rem, 4vw, 3rem) 1.5rem;
+}
+
+.screen.active {
+  display: flex;
+}
+
+.splash-screen {
+  align-items: center;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  gap: 1.5rem;
+}
+
+.logo-badge {
+  align-items: center;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.65), rgba(255, 255, 255, 0.2));
+  border: 1px solid var(--card-border);
+  border-radius: 28px;
+  box-shadow: 0 28px 60px rgba(245, 124, 0, 0.25);
+  color: var(--orange);
+  display: inline-flex;
+  font-size: clamp(2rem, 6vw, 3.5rem);
+  font-weight: 700;
+  height: clamp(120px, 22vw, 160px);
+  justify-content: center;
+  letter-spacing: 0.1em;
+  padding: 0 1.5rem;
+  text-transform: uppercase;
+  text-shadow: 0 12px 24px rgba(245, 124, 0, 0.28);
+}
+
+.splash-text {
+  font-size: clamp(1.4rem, 2.5vw, 2.4rem);
+  font-weight: 600;
+}
+
+.onboarding {
+  background: transparent;
+  flex-direction: column;
+}
+
+.onboarding-visual {
+  background: radial-gradient(circle at 20% 30%, rgba(255, 255, 255, 0.6), transparent 60%),
+    radial-gradient(circle at 80% 40%, rgba(255, 183, 77, 0.45), transparent 65%), var(--muted-yellow);
+  flex: 1 1 40%;
+  overflow: hidden;
+  position: relative;
+}
+
+.visual-blob {
+  border-radius: 50%;
+  filter: blur(0px);
+  opacity: 0.6;
+  position: absolute;
+}
+
+.blob-one {
+  background: #ffcc80;
+  height: 220px;
+  left: 15%;
+  top: 18%;
+  width: 220px;
+}
+
+.blob-two {
+  background: #ffab40;
+  bottom: 10%;
+  height: 320px;
+  right: 18%;
+  width: 320px;
+}
+
+.visual-glyph {
+  color: rgba(121, 85, 72, 0.35);
+  font-size: clamp(6rem, 18vw, 12rem);
+  left: 50%;
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%) rotate(-12deg);
+}
+
+.onboarding-card {
+  background: var(--card-surface);
+  backdrop-filter: blur(18px);
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.12);
+  padding: clamp(1.5rem, 5vw, 3rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.onboarding-slide {
+  display: grid;
+  gap: 1.2rem;
+  text-align: center;
+}
+
+.onboarding-slide .slide-visual {
+  align-items: center;
+  background: linear-gradient(135deg, rgba(245, 124, 0, 0.15), rgba(251, 192, 45, 0.4));
+  border-radius: 32px;
+  color: #f57c00;
+  display: inline-flex;
+  font-size: clamp(3rem, 12vw, 5rem);
+  height: clamp(120px, 22vw, 160px);
+  justify-content: center;
+  margin: 0 auto;
+  width: clamp(160px, 40vw, 220px);
+}
+
+.onboarding-slide .slide-visual.accent-growth {
+  background: linear-gradient(135deg, rgba(76, 175, 80, 0.2), rgba(129, 199, 132, 0.45));
+  color: #2e7d32;
+}
+
+.onboarding-slide .slide-visual.accent-price {
+  background: linear-gradient(135deg, rgba(255, 152, 0, 0.2), rgba(255, 204, 128, 0.55));
+  color: #ef6c00;
+}
+
+.onboarding-slide h2 {
+  font-size: clamp(1.8rem, 3vw, 2.7rem);
+  font-weight: 600;
+}
+
+.onboarding-slide p {
+  font-size: clamp(1rem, 2.4vw, 1.3rem);
+  color: rgba(31, 31, 31, 0.7);
+  line-height: 1.6;
+}
+
+.progress-wrapper {
+  display: flex;
+  justify-content: center;
+}
+
+.progress-bar {
+  background: rgba(0, 0, 0, 0.08);
+  border-radius: 999px;
+  height: 8px;
+  overflow: hidden;
+  width: min(340px, 90%);
+}
+
+.progress-indicator {
+  background: linear-gradient(90deg, #f79f1f, #f7c04a);
+  height: 100%;
+  transition: width var(--transition);
+  width: 0;
+}
+
+.onboarding-actions {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.btn {
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 600;
+  padding: 0.9rem 1.2rem;
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.btn:focus-visible {
+  outline: 3px solid rgba(247, 159, 31, 0.5);
+  outline-offset: 2px;
+}
+
+.btn.primary {
+  background: linear-gradient(120deg, #fcd45d, #f79f1f);
+  color: var(--dark);
+  box-shadow: 0 12px 24px rgba(247, 159, 31, 0.2);
+}
+
+.btn.primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 34px rgba(247, 159, 31, 0.25);
+}
+
+.btn.ghost {
+  background: transparent;
+  color: var(--orange);
+}
+
+.btn.ghost:hover {
+  transform: translateY(-2px);
+}
+
+.btn.outlined {
+  background: transparent;
+  border: 2px solid rgba(247, 159, 31, 0.6);
+  color: var(--dark);
+}
+
+.home {
+  align-items: center;
+  background: transparent;
+  flex-direction: column;
+  gap: 2rem;
+  padding: clamp(2rem, 4vw, 4rem) 1.5rem;
+}
+
+.home-header {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: clamp(1rem, 5vw, 5rem);
+  text-align: center;
+}
+
+.home-header h1 {
+  font-size: clamp(1.8rem, 4vw, 2.5rem);
+  font-weight: 600;
+  max-width: 560px;
+}
+
+.brand-title {
+  background: linear-gradient(135deg, #f57c00, #ef6c00, #fbc02d);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  font-size: clamp(2rem, 6vw, 3.6rem);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.scan-options {
+  background: var(--card-surface);
+  backdrop-filter: blur(18px);
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 30px 45px rgba(0, 0, 0, 0.18);
+  display: grid;
+  gap: 1rem;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  width: min(680px, 100%);
+}
+
+.scan-option {
+  align-items: center;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  display: flex;
+  gap: 1.2rem;
+  padding: 1.1rem 1.3rem;
+  text-align: left;
+  transition: background var(--transition), transform var(--transition), box-shadow var(--transition);
+}
+
+.scan-option:hover {
+  background: rgba(247, 159, 31, 0.12);
+  transform: translateY(-2px);
+  box-shadow: 0 16px 30px rgba(0, 0, 0, 0.08);
+}
+
+.scan-option .scan-icon {
+  align-items: center;
+  background: linear-gradient(135deg, rgba(245, 124, 0, 0.12), rgba(251, 192, 45, 0.4));
+  border-radius: 20px;
+  color: #f57c00;
+  display: inline-flex;
+  font-size: clamp(1.8rem, 4vw, 2.3rem);
+  height: clamp(52px, 9vw, 64px);
+  justify-content: center;
+  width: clamp(52px, 9vw, 64px);
+}
+
+.scan-icon.upload::before {
+  content: "⬆️";
+}
+
+.scan-icon.camera::before {
+  content: "📷";
+}
+
+.scan-option h2 {
+  font-size: clamp(1.2rem, 2.8vw, 1.5rem);
+}
+
+.scan-option p {
+  color: rgba(31, 31, 31, 0.7);
+  font-size: clamp(0.95rem, 2.4vw, 1.05rem);
+  line-height: 1.5;
+  margin-top: 0.35rem;
+}
+
+.result {
+  align-items: center;
+  background: transparent;
+  flex-direction: column;
+  gap: 2rem;
+  padding: clamp(2rem, 5vw, 4rem) 1.5rem clamp(3rem, 5vw, 5rem);
+}
+
+.result-card {
+  background: var(--card-surface);
+  backdrop-filter: blur(18px);
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 40px 60px rgba(0, 0, 0, 0.2);
+  display: grid;
+  gap: 1.5rem;
+  max-width: 720px;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  width: min(720px, 100%);
+}
+
+.result-image {
+  background: rgba(247, 159, 31, 0.1);
+  border-radius: var(--radius-md);
+  max-height: 320px;
+  overflow: hidden;
+}
+
+.result-image img {
+  height: 100%;
+  object-fit: contain;
+  width: 100%;
+}
+
+.result-details {
+  display: grid;
+  gap: 1rem;
+}
+
+.result-details dt {
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.result-details dd {
+  font-size: clamp(1.1rem, 2.4vw, 1.4rem);
+  font-weight: 500;
+}
+
+.confidence {
+  align-items: center;
+  display: flex;
+  gap: 1rem;
+}
+
+.result-info,
+.result-error {
+  background: rgba(220, 53, 69, 0.1);
+  border-left: 4px solid #dc3545;
+  border-radius: 0 12px 12px 0;
+  color: #8a1c26;
+  margin-top: 0.5rem;
+  padding: 0.75rem 1rem;
+}
+
+.result-info {
+  background: rgba(33, 150, 243, 0.14);
+  border-left-color: rgba(33, 150, 243, 0.75);
+  color: #0d47a1;
+}
+
+.result-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: min(420px, 100%);
+}
+
+.toast {
+  background: rgba(31, 31, 31, 0.9);
+  border-radius: var(--radius-sm);
+  color: var(--light);
+  left: 50%;
+  padding: 0.75rem 1.1rem;
+  position: fixed;
+  top: 1.5rem;
+  transform: translateX(-50%);
+  z-index: 1200;
+}
+
+.sr-only {
+  border: 0 !important;
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute !important;
+  width: 1px;
+  white-space: nowrap;
+}
+
+@media (min-width: 960px) {
+  .onboarding {
+    flex-direction: row;
+    gap: 4rem;
+    padding: clamp(3rem, 6vw, 5rem) clamp(3rem, 8vw, 6rem);
+  }
+
+  .onboarding-visual {
+    flex: 1 1 50%;
+  }
+
+  .onboarding-card {
+    border-radius: var(--radius-lg);
+    flex: 0 1 460px;
+    justify-content: center;
+    margin-left: -2rem;
+  }
+
+  .onboarding-actions {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .result-actions {
+    flex-direction: row;
+    justify-content: center;
+  }
+
+  .result-actions .btn {
+    flex: 1 1 auto;
+  }
+}

--- a/web/styles.css
+++ b/web/styles.css
@@ -50,7 +50,7 @@ body {
 }
 
 .analysis-banner::before {
-  content: "⏳";
+  content: attr(data-icon);
   font-size: 1.25rem;
 }
 


### PR DESCRIPTION
## Summary
- add a helper script that copies the web build into build/<name> and boots a fresh git history for GitHub
- document the one-command export flow in both READMEs so macOS users can push the web app immediately

## Testing
- ./scripts/prepare-web-repo.sh test-web-repo

------
https://chatgpt.com/codex/tasks/task_e_68e61c6b3a00832cb3da0fcaf4218397